### PR TITLE
window resized, grid layout fixed, WIP: view page layout

### DIFF
--- a/trucker_time_logger.py
+++ b/trucker_time_logger.py
@@ -3,8 +3,7 @@ from tkinter import *
 from tkinter import ttk
 from tkinter import filedialog
 
-
-
+import viewpage
 
 
 
@@ -12,11 +11,11 @@ from tkinter import filedialog
 class file_manage:
     def __init__(self, root):
         self.root = root
-        self.root.geometry("560x350")
+        self.root.geometry("800x350")
         customtkinter.set_appearance_mode("light")
         customtkinter.set_default_color_theme("blue")
         self.file_Names = []
-        self. frame = ""
+        self.frame = ""
         self.setup_gui()
 
     def setup_gui(self):
@@ -24,8 +23,7 @@ class file_manage:
         self.frame = customtkinter.CTkFrame(master=root)
 
         self.frame.pack(pady =20,padx = 60, fill = "both", expand = True)
-
-
+        self.frame.grid_columnconfigure((0,1,2), weight=1)
 
      
 
@@ -47,7 +45,7 @@ class file_manage:
                                           width = 120,
                                           fg_color = "#d7c5db",
                                           corner_radius = 25)
-        button2.grid (row = 1, column = 2, padx = 10, pady = 10)
+        button2.grid (row = 1, column = 1, padx = 10, pady = 10)
 
 
         button3 = customtkinter.CTkButton(master = self.frame,
@@ -56,7 +54,7 @@ class file_manage:
                                           height = 50,
                                           width = 120,
                                           corner_radius = 25)
-        button3.grid (row = 1, column = 3, padx = 10, pady = 10)
+        button3.grid (row = 1, column = 2, padx = 10, pady = 10)
 
 
     def login(self):
@@ -88,7 +86,7 @@ class file_manage:
                                           width = 120,
                                           fg_color = "#d7c5db",
                                           corner_radius = 25)
-        button2.grid (row = 1, column = 2, padx = 10, pady = 10)
+        button2.grid (row = 1, column = 1, padx = 10, pady = 10)
 
 
         button3 = customtkinter.CTkButton(master = self.frame,
@@ -97,7 +95,10 @@ class file_manage:
                                           height = 10,
                                           width = 120,
                                           corner_radius = 25)
-        button3.grid (row = 1, column = 3, padx = 10, pady = 10)
+        button3.grid (row = 1, column = 2, padx = 10, pady = 10)
+
+        page = viewpage.ViewPage(self.frame)
+        page.grid(row=2, column=0, columnspan=3, padx = 10, pady = 10, sticky="swe")
 
 
     def Analytics(self):
@@ -125,7 +126,7 @@ class file_manage:
                                           width = 120,
                                           fg_color = "#d7c5db",
                                           corner_radius = 25)
-        button2.grid (row = 1, column = 2, padx = 10, pady = 10)
+        button2.grid (row = 1, column = 1, padx = 10, pady = 10)
 
 
         button3 = customtkinter.CTkButton(master = self.frame,
@@ -134,7 +135,7 @@ class file_manage:
                                           height = 50,
                                           width = 120,
                                           corner_radius = 25)
-        button3.grid (row = 1, column = 3, padx = 10, pady = 10)
+        button3.grid (row = 1, column = 2, padx = 10, pady = 10)
 
 
     def DailyLog(self):
@@ -163,7 +164,7 @@ class file_manage:
                                           width = 120,
                                           fg_color = "#d7c5db",
                                           corner_radius = 25)
-        button2.grid (row = 1, column = 2, padx = 10, pady = 10)
+        button2.grid (row = 1, column = 1, padx = 10, pady = 10)
 
 
         button3 = customtkinter.CTkButton(master = self.frame,
@@ -172,7 +173,7 @@ class file_manage:
                                           height = 20,
                                           width = 120,
                                           corner_radius = 25)
-        button3.grid (row = 1, column = 3, padx = 10, pady = 10)
+        button3.grid (row = 1, column = 2, padx = 10, pady = 10)
 
         
         

--- a/viewpage.py
+++ b/viewpage.py
@@ -1,0 +1,68 @@
+import customtkinter
+
+class ViewPage(customtkinter.CTkFrame):
+    def __init__(self, master):
+        super().__init__(master)
+
+        self.logDetail = customtkinter.CTkFrame(self)
+        self.logDetail.pack(expand=True, side="right", fill="both", padx=10, pady=10)
+        self.logDetail.grid_rowconfigure((0,2), weight=1)
+        self.logDetail.grid_rowconfigure((1,3,4), weight=2)
+        self.logDetail.grid_columnconfigure((0,1,2,3), weight=1)
+
+        self.DTLabel = customtkinter.CTkLabel(self.logDetail, text="Driving Time")
+        self.DTLabel.grid(row=0, column=0, columnspan=2, padx=10, sticky="sw")
+
+        self.DTInput = customtkinter.CTkEntry(self.logDetail)
+        self.DTInput.grid(row=1, column=0, columnspan=2, padx=10, sticky="nswe")
+
+        self.RTLabel = customtkinter.CTkLabel(self.logDetail, text="Resting Time")
+        self.RTLabel.grid(row=0, column=2, columnspan=2, padx=10, sticky="sw")
+
+        self.RTInput = customtkinter.CTkEntry(self.logDetail)
+        self.RTInput.grid(row=1, column=2, columnspan=2, padx=10, sticky="nswe")
+
+        self.dateLabel = customtkinter.CTkLabel(self.logDetail, text="Date")
+        self.dateLabel.grid(row=2, column=0, columnspan=2, padx=10, sticky="sw")
+
+        self.dateInput = customtkinter.CTkEntry(self.logDetail)
+        self.dateInput.grid(row=3, column=0, columnspan=2, padx=10, sticky="nswe")
+
+        self.timeLabel = customtkinter.CTkLabel(self.logDetail, text="Time")
+        self.timeLabel.grid(row=2, column=2, columnspan=2, padx=10, sticky="sw")
+        
+        self.timeInput = customtkinter.CTkEntry(self.logDetail)
+        self.timeInput.grid(row=3, column=2, columnspan=2, padx=10, sticky="nswe")
+
+        self.updateBtn = customtkinter.CTkButton(self.logDetail, 
+                                                 text="UPDATE", 
+                                                 command=self.updateDetail)
+        self.updateBtn.grid(row=4, column=1, columnspan=2)
+
+        self.resetBtn = customtkinter.CTkButton(self.logDetail, 
+                                                width=70, 
+                                                height=14, 
+                                                command=self.resetDetail,
+                                                text="reset", 
+                                                text_color="white", 
+                                                fg_color="transparent", 
+                                                hover_color="Red")
+        self.resetBtn.grid(row=4, column=0, padx=10, pady=10, sticky="w")
+
+        self.selectionFrame = customtkinter.CTkScrollableFrame(self)
+        self.selectionFrame.pack(fill="y", side="left", padx=10, pady=10)
+
+        self.entrybtn1 = customtkinter.CTkButton(self.selectionFrame, 
+                                                 text="02/26/2025 10:27AM", 
+                                                 command=lambda: self.entryDisplay(self.entrybtn1))
+        self.entrybtn1.pack(pady=5, fill="x")
+        
+
+    def updateDetail(self):
+        print("update log ")
+    
+    def resetDetail(self):
+        print("reset")
+
+    def entryDisplay(self, btn):
+        print(btn.cget("text"))


### PR DESCRIPTION
1. Enlarge the window size of the whole program
2. Put weight equally on each column
3. fixed the column number for buttons, i.e. 0,1,2 so they were equally distributed
4. Work In Progress: introduce the class ViewPage in a new file viewpage.py. Which generates a frame that contains a frame for the list of log items and a frame that contains input area and buttons for updating / edit log data.
[image](https://github.com/user-attachments/assets/78b8692f-dddf-45dc-a179-38c59583df91)
