### PR TITLE
Improvement on ViewPage, SelectionWindow, and CustomDateEntry

### DIFF
--- a/custom_date_entry.py
+++ b/custom_date_entry.py
@@ -30,7 +30,7 @@ class CustomDateEntry (ctk.CTkFrame):
     def create_date_entry(self):
         """generate a new date entry box, if exists already, will delete it before create new box."""
         if self.date_entry != None:
-            self.date_entry.pack_forget()
+            self.date_entry.destroy()
 
         if self.is_win:
             self.date_entry = tkcalendar.DateEntry(self, font = self.tk_font

--- a/custom_window.py
+++ b/custom_window.py
@@ -40,6 +40,12 @@ class SelectionWindow(ctk.CTkToplevel):
         self.content_frame.grid_forget()
         self.content_frame.set(msg_list, column_weights, header=header)
         self.content_frame.grid(row = 0, column = 0, sticky = "nsew", padx = 10, pady = 10)
+    
+    def center(self):
+        """move the popup window to the middle of screen"""
+        x = self.winfo_screenwidth() / 2 - self.winfo_width() / 2
+        y = self.winfo_screenheight() / 2 - self.winfo_height() / 2
+        self.geometry(f"""+{int(x)}+{int(y)}""")
 
 
 class FormattedTextFrame(ctk.CTkFrame):

--- a/viewpage.py
+++ b/viewpage.py
@@ -482,6 +482,7 @@ class ViewPage(customtkinter.CTkFrame):
 
         self.last_change = []
         self.undo_btn.grid_forget()
+        self.pop_msg("Undo Complete.")
         self.remove_cover()
 
     def clear_button_click(self):
@@ -497,10 +498,11 @@ class ViewPage(customtkinter.CTkFrame):
         self.selected_index = -1
         self.remove_cover()
 
-    def pop_msg(self, msg : str):
+    def pop_msg(self, msg : str, width = 350, height = 150):
         """Pop up window to show a message"""
         popup = SelectionWindow(title = "Message", options=["Done"], var=customtkinter.StringVar())
-        popup.geometry("300x100")
+        popup.geometry(f'{width}x{height}')
+        popup.center()
         popup.set_content([[msg]],[1])
         popup.focus()
         popup.grab_set()
@@ -527,10 +529,12 @@ class ViewPage(customtkinter.CTkFrame):
             header = msg_list[0][0]
             msg_list = msg_list[1:]
         if(popup == None or not popup.winfo_exists()):
-            popup = SelectionWindow(title="Acition Confirm"
+            popup = SelectionWindow(title="Action Confirm"
                                     , options = ["Yes", "Cancel"]
                                     , var = confirmation)
             popup.set_content(msg_list, columns, header)
+            popup.center()
+            popup.focus()
             popup.grab_set()
             self.wait_window(popup)
         else:


### PR DESCRIPTION
- Fix problem in CustomDateEntry that calendar continue exist after a new date is set
- Add center() method for SelectionWindow to position the window to the middle of the screen
- Apply the center() method to all popup window in Viewpage.
- Improve the event reaction time in Viewpage by improve the algorithm for finding the correct index of target entry.
- Loading screen display when slower changes is taking place in Viewpage. That is, no longer seeing the entry shifting up and down after update, undo, etc. or the number changing one by one.