### PR TITLE
Fix scaling issue in Window when screen is scaled

### DIFF
--- a/trucker_time_logger.py
+++ b/trucker_time_logger.py
@@ -9,6 +9,8 @@ import analytics as Analytics
 
 import fileSelector
 
+import ctypes
+ctypes.windll.shcore.SetProcessDpiAwareness(0)
 
 class file_manage:
     def __init__(self, root):


### PR DESCRIPTION
- In Window setting, scale is set different to 100% will cause errors in component sizing, now is fixed for image and maybe for other widgets.